### PR TITLE
Teensyduino Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: build
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  IDE_VERSION: 1.8.15
-  TEENSY_VERSION: 154
+  IDE_VERSION: 1.8.16
+  TEENSY_VERSION: 155
   IDE_LOCATION: /usr/local/share/arduino
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,6 @@ jobs:
 
       - name: Teensy 4.1
         run: arduino --verify --board teensy:avr:teensy41:usb=${{ matrix.usb_mode }},speed=600,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy MicroMod
+        run: arduino --verify --board teensy:avr:teensyMM:usb=${{ matrix.usb_mode }},speed=600,opt=o2std,keys=en-us ${{ matrix.sketch }};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,9 @@ jobs:
 
       - name: Teensy 3.6
         run: arduino --verify --board teensy:avr:teensy36:usb=${{ matrix.usb_mode }},speed=180,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy 4.0
+        run: arduino --verify --board teensy:avr:teensy40:usb=${{ matrix.usb_mode }},speed=600,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy 4.1
+        run: arduino --verify --board teensy:avr:teensy41:usb=${{ matrix.usb_mode }},speed=600,opt=o2std,keys=en-us ${{ matrix.sketch }};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: build
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  IDE_VERSION: 1.8.13
+  TEENSY_VERSION: 153
+  IDE_LOCATION: /usr/local/share/arduino
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        compilation: ['Serial: Blank Sketch', 'NS Gadget: Blank Sketch', 'NSGamepad Example', 'NSPassthru Example', 'NSMIDI Example']
+        include:
+          - compilation: 'Serial: Blank Sketch'
+            sketch: "$IDE_LOCATION/examples/01.Basics/BareMinimum/BareMinimum.ino"
+            usb_mode: serial
+          - compilation: 'NS Gadget: Blank Sketch'
+            sketch: "$IDE_LOCATION/examples/01.Basics/BareMinimum/BareMinimum.ino"
+            usb_mode: nsgamepad
+          - compilation: 'NSGamepad Example'
+            sketch: "./examples/NSGamepad/NSGamepad.ino"
+            usb_mode: nsgamepad
+          - compilation: 'NSPassthru Example'
+            sketch: "./examples/NSGamepad/NSPassthru.ino"
+            usb_mode: nsgamepad
+          - compilation: 'NSMIDI Example'
+            sketch: "./examples/NSGamepad/NSMIDI.ino"
+            usb_mode: nsgamepad
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Arduino IDE
+        run: |
+          wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+          tar xf arduino-$IDE_VERSION-linux64.tar.xz
+          sudo mv arduino-$IDE_VERSION /usr/local/share/arduino
+          sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+          rm arduino-$IDE_VERSION-linux64.tar.xz
+
+      - name: Install Teensyduino
+        run: |
+          wget https://www.pjrc.com/teensy/td_$TEENSY_VERSION/TeensyduinoInstall.linux64;
+          chmod +x ./TeensyduinoInstall.linux64;
+          sudo ./TeensyduinoInstall.linux64 --dir=/usr/local/share/arduino;
+          rm ./TeensyduinoInstall.linux64;
+
+      - name: Copy NS Gadget Teensy Files
+        run: sudo \cp -r hardware $IDE_LOCATION;
+      
+      - name: Remove Teensy Loader Trigger
+        run: sudo python ./.github/workflows/remove_teensyloader.py $IDE_LOCATION/hardware/teensy/avr/platform.txt
+
+      - name: Teensy LC
+        run: arduino --verify --board teensy:avr:teensyLC:usb=${{ matrix.usb_mode }},speed=48,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy 3.1/ 3.2
+        run: arduino --verify --board teensy:avr:teensy31:usb=${{ matrix.usb_mode }},speed=72,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy 3.5
+        run: arduino --verify --board teensy:avr:teensy35:usb=${{ matrix.usb_mode }},speed=120,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy 3.6
+        run: arduino --verify --board teensy:avr:teensy36:usb=${{ matrix.usb_mode }},speed=180,opt=o2std,keys=en-us ${{ matrix.sketch }};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: build
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  IDE_VERSION: 1.8.16
-  TEENSY_VERSION: 155
+  IDE_VERSION: 1.8.19
+  TEENSY_VERSION: 156
   IDE_LOCATION: /usr/local/share/arduino
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: build
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  IDE_VERSION: 1.8.13
-  TEENSY_VERSION: 153
+  IDE_VERSION: 1.8.15
+  TEENSY_VERSION: 154
   IDE_LOCATION: /usr/local/share/arduino
 
 jobs:

--- a/.github/workflows/remove_teensyloader.py
+++ b/.github/workflows/remove_teensyloader.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+import sys
+import re
+
+filepath = sys.argv[1]  # path of the file to parse
+lines = []  # list of lines from the file
+removed = False  # flag for if the line was removed from the file
+
+with open(filepath, 'r') as f:
+	lines = f.readlines()
+
+with open(filepath, 'w') as f:
+	# matching "postbuild" hooks of any number which call the "teensy_post_compile" application
+	pattern = re.compile("recipe\.hooks\.postbuild\.[0-9]\.pattern=\"{compiler\.path}teensy_post_compile\"")
+	for line in lines:
+		if not pattern.match(line):
+			f.write(line)
+		else:
+			print("Removing line '{}'".format(line.strip('\n')))
+			removed = True
+
+if not removed:
+	raise RuntimeError("Did not find a matching line to remove in \"{}\"".format(filepath))

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,8 @@
 *.out
 *.app
 
-arduino-1.8.13
+## ----------------------------------------------------
+## NSGadget_Teensy
+
+# Arduino IDE
+arduino-*.*.*

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,33 @@
 
 # Arduino IDE
 arduino-*.*.*
+
+# Teensy Modifications
+hardware/teensy/**
+!hardware/teensy/avr/boards.txt
+!hardware/teensy/avr/keywords.txt
+
+# USB Host T36 Library (To Keep)
+#!hardware/teensy/avr/libraries/USBHost_t36
+
+# Teensy 3 Core (To Keep)
+!hardware/teensy/avr/cores/teensy3/
+!hardware/teensy/avr/cores/teensy3/usb_desc.c
+!hardware/teensy/avr/cores/teensy3/usb_desc.h
+!hardware/teensy/avr/cores/teensy3/usb_dev.c
+!hardware/teensy/avr/cores/teensy3/usb_inst.cpp
+!hardware/teensy/avr/cores/teensy3/usb_nsgamepad.c
+!hardware/teensy/avr/cores/teensy3/usb_nsgamepad.h
+!hardware/teensy/avr/cores/teensy3/WProgram.h
+!hardware/teensy/avr/cores/teensy3/yield.cpp
+
+# Teensy 4 Core (To Keep)
+!hardware/teensy/avr/cores/teensy4/
+!hardware/teensy/avr/cores/teensy4/usb.c
+!hardware/teensy/avr/cores/teensy4/usb_desc.c
+!hardware/teensy/avr/cores/teensy4/usb_desc.h
+!hardware/teensy/avr/cores/teensy4/usb_inst.cpp
+!hardware/teensy/avr/cores/teensy4/usb_nsgamepad.c
+!hardware/teensy/avr/cores/teensy4/usb_nsgamepad.h
+!hardware/teensy/avr/cores/teensy4/WProgram.h
+!hardware/teensy/avr/cores/teensy4/yield.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ hardware/teensy/**
 !hardware/teensy/avr/cores/teensy3/usb_inst.cpp
 !hardware/teensy/avr/cores/teensy3/usb_nsgamepad.c
 !hardware/teensy/avr/cores/teensy3/usb_nsgamepad.h
+!hardware/teensy/avr/cores/teensy3/usb_serial.h
 !hardware/teensy/avr/cores/teensy3/WProgram.h
 !hardware/teensy/avr/cores/teensy3/yield.cpp
 
@@ -64,5 +65,6 @@ hardware/teensy/**
 !hardware/teensy/avr/cores/teensy4/usb_inst.cpp
 !hardware/teensy/avr/cores/teensy4/usb_nsgamepad.c
 !hardware/teensy/avr/cores/teensy4/usb_nsgamepad.h
+!hardware/teensy/avr/cores/teensy3/usb_serial.h
 !hardware/teensy/avr/cores/teensy4/WProgram.h
 !hardware/teensy/avr/cores/teensy4/yield.cpp

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ https://github.com/gdsports/NSGadget_Pi.
 
 ## Install
 
-Install the [Arduino IDE 1.8.15](https://www.arduino.cc/en/Main/Software) and
-[Teensyduino 1.54](https://www.pjrc.com/teensy/td_154/). I highly
+Install the [Arduino IDE 1.8.16](https://www.arduino.cc/en/Main/Software) and
+[Teensyduino 1.55](https://www.pjrc.com/teensy/td_155/). I highly
 recommend extracting the IDE zip or tar in a separate directory from the
 default Arduino directory.
 
 On a Linux system, the following instructions will install the IDE into
-`~/nsg/arduino-1.8.15`. Creating the portable directory ensures the sketches and
+`~/nsg/arduino-1.8.16`. Creating the portable directory ensures the sketches and
 libraries are stored separately from the default Arduino sketches and
 libraries.
 
@@ -51,15 +51,15 @@ libraries.
 cd
 mkdir nsg
 cd nsg
-tar xf ~/Downloads/arduino-1.8.15-linux64.tar.xz
-cd arduino-1.8.15
+tar xf ~/Downloads/arduino-1.8.16-linux64.tar.xz
+cd arduino-1.8.16
 mkdir portable
 ```
 
-Run the Teensyduino installer. Make sure to install in the arduino-1.8.15
+Run the Teensyduino installer. Make sure to install in the arduino-1.8.16
 directory created above.
 
-Copy the files in this repo's hardware directory to the arduino-1.8.15/hardware
+Copy the files in this repo's hardware directory to the arduino-1.8.16/hardware
 directory. This will overwrite Teensyduino files.
 
 Start the IDE with all changes. The examples should build without changes. If
@@ -67,7 +67,7 @@ compile errors occur, be sure the Board is set to "Teensy 3.6" and the USB Type
 is set to "NS Gamepad".
 
 ```
-cd ~/nsg/arduino-1.8.15
+cd ~/nsg/arduino-1.8.16
 ./arduino&
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Arduino NS Gamepad for Teensy
+[![Build Status](https://github.com/gdsports/NSGadget_Teensy/workflows/build/badge.svg?branch=master)](https://github.com/gdsports/NSGadget_Teensy/actions?query=workflow%3Abuild)
 
 USB NS Gamepad provides a Nintendo Switch (NS) compatible gamepad. This is
 useful for building an arcade console or to adapt other USB devices for use

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arduino NS Gamepad for Teensy
-[![Build Status](https://github.com/gdsports/NSGadget_Teensy/workflows/build/badge.svg?branch=master)](https://github.com/gdsports/NSGadget_Teensy/actions?query=workflow%3Abuild)
+[![Build Status](../../workflows/build/badge.svg?branch=master)](../../actions?query=workflow%3Abuild)
 
 USB NS Gamepad provides a Nintendo Switch (NS) compatible gamepad. This is
 useful for building an arcade console or to adapt other USB devices for use

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ https://github.com/gdsports/NSGadget_Pi.
 
 ## Install
 
-Install the [Arduino IDE 1.8.13](https://www.arduino.cc/en/Main/Software) and
-[Teensyduino 1.53](https://www.pjrc.com/teensy/td_download.html). I highly
+Install the [Arduino IDE 1.8.15](https://www.arduino.cc/en/Main/Software) and
+[Teensyduino 1.54](https://www.pjrc.com/teensy/td_154/). I highly
 recommend extracting the IDE zip or tar in a separate directory from the
 default Arduino directory.
 
 On a Linux system, the following instructions will install the IDE into
-`~/nsg/arduino-1.8.13`. Creating the portable directory ensures the sketches and
+`~/nsg/arduino-1.8.15`. Creating the portable directory ensures the sketches and
 libraries are stored separately from the default Arduino sketches and
 libraries.
 
@@ -51,15 +51,15 @@ libraries.
 cd
 mkdir nsg
 cd nsg
-tar xf ~/Downloads/arduino-1.8.13-linux64.tar.xz
-cd arduino-1.8.13
+tar xf ~/Downloads/arduino-1.8.15-linux64.tar.xz
+cd arduino-1.8.15
 mkdir portable
 ```
 
-Run the Teensyduino installer. Make sure to install in the arduino-1.8.13
+Run the Teensyduino installer. Make sure to install in the arduino-1.8.15
 directory created above.
 
-Copy the files in this repo's hardware directory to the arduino-1.8.13/hardware
+Copy the files in this repo's hardware directory to the arduino-1.8.15/hardware
 directory. This will overwrite Teensyduino files.
 
 Start the IDE with all changes. The examples should build without changes. If
@@ -67,7 +67,7 @@ compile errors occur, be sure the Board is set to "Teensy 3.6" and the USB Type
 is set to "NS Gamepad".
 
 ```
-cd ~/nsg/arduino-1.8.13
+cd ~/nsg/arduino-1.8.15
 ./arduino&
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ https://github.com/gdsports/NSGadget_Pi.
 
 ## Install
 
-Install the [Arduino IDE 1.8.16](https://www.arduino.cc/en/Main/Software) and
-[Teensyduino 1.55](https://www.pjrc.com/teensy/td_155/). I highly
+Install the [Arduino IDE 1.8.19](https://www.arduino.cc/en/Main/Software) and
+[Teensyduino 1.56](https://www.pjrc.com/teensy/td_156/). I highly
 recommend extracting the IDE zip or tar in a separate directory from the
 default Arduino directory.
 
 On a Linux system, the following instructions will install the IDE into
-`~/nsg/arduino-1.8.16`. Creating the portable directory ensures the sketches and
+`~/nsg/arduino-1.8.19`. Creating the portable directory ensures the sketches and
 libraries are stored separately from the default Arduino sketches and
 libraries.
 
@@ -51,15 +51,15 @@ libraries.
 cd
 mkdir nsg
 cd nsg
-tar xf ~/Downloads/arduino-1.8.16-linux64.tar.xz
-cd arduino-1.8.16
+tar xf ~/Downloads/arduino-1.8.19-linux64.tar.xz
+cd arduino-1.8.19
 mkdir portable
 ```
 
-Run the Teensyduino installer. Make sure to install in the arduino-1.8.16
+Run the Teensyduino installer. Make sure to install in the arduino-1.8.19
 directory created above.
 
-Copy the files in this repo's hardware directory to the arduino-1.8.16/hardware
+Copy the files in this repo's hardware directory to the arduino-1.8.19/hardware
 directory. This will overwrite Teensyduino files.
 
 Start the IDE with all changes. The examples should build without changes. If
@@ -67,7 +67,7 @@ compile errors occur, be sure the Board is set to "Teensy 3.6" and the USB Type
 is set to "NS Gamepad".
 
 ```
-cd ~/nsg/arduino-1.8.16
+cd ~/nsg/arduino-1.8.19
 ./arduino&
 ```
 

--- a/hardware/teensy/avr/boards.txt
+++ b/hardware/teensy/avr/boards.txt
@@ -292,6 +292,12 @@ teensyMM.menu.usb.flightsim.fake_serial=teensy_gateway
 teensyMM.menu.usb.flightsimjoystick=Flight Sim Controls + Joystick
 teensyMM.menu.usb.flightsimjoystick.build.usbtype=USB_FLIGHTSIM_JOYSTICK
 teensyMM.menu.usb.flightsimjoystick.fake_serial=teensy_gateway
+teensyMM.menu.usb.joystick=Joystick
+teensyMM.menu.usb.joystick.build.usbtype=USB_JOYSTICK
+#teensyMM.menu.usb.joystickserial=Joystick + Serial
+#teensyMM.menu.usb.joystickserial.build.usbtype=USB_SERIAL_JOYSTICK
+teensyMM.menu.usb.nsgamepad=NS Gamepad
+teensyMM.menu.usb.nsgamepad.build.usbtype=USB_NSGAMEPAD
 #teensyMM.menu.usb.disable=No USB
 #teensyMM.menu.usb.disable.build.usbtype=USB_DISABLED
 

--- a/hardware/teensy/avr/boards.txt
+++ b/hardware/teensy/avr/boards.txt
@@ -4,6 +4,15 @@ menu.opt=Optimize
 menu.keys=Keyboard Layout
 
 
+# TODO: consider whether these compiler warnings are worthwhile
+# -Wno-error=unused-function
+# -Wno-error=unused-but-set-variable
+# -Wno-error=unused-variable
+# -Wno-unused-parameter
+# -Wno-unused-but-set-parameter
+# -Wno-sign-compare
+
+
 teensy41.name=Teensy 4.1
 #teensy41.upload.maximum_size=8126464
 teensy41.build.board=TEENSY41
@@ -26,7 +35,7 @@ teensy41.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy41.build.flags.dep=-MMD
 teensy41.build.flags.optimize=-Os
 teensy41.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=154
+teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=155
 teensy41.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy41.build.flags.c=
 teensy41.build.flags.S=-x assembler-with-cpp
@@ -232,7 +241,7 @@ teensyMM.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensyMM.build.flags.dep=-MMD
 teensyMM.build.flags.optimize=-Os
 teensyMM.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=154
+teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=155
 teensyMM.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensyMM.build.flags.c=
 teensyMM.build.flags.S=-x assembler-with-cpp
@@ -438,7 +447,7 @@ teensy40.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy40.build.flags.dep=-MMD
 teensy40.build.flags.optimize=-Os
 teensy40.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=154
+teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=155
 teensy40.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy40.build.flags.c=
 teensy40.build.flags.S=-x assembler-with-cpp
@@ -640,7 +649,7 @@ teensy36.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy36.build.flags.dep=-MMD
 teensy36.build.flags.optimize=-Os
 teensy36.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=154
+teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=155
 teensy36.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy36.build.flags.c=
 teensy36.build.flags.S=-x assembler-with-cpp
@@ -857,7 +866,7 @@ teensy35.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy35.build.flags.dep=-MMD
 teensy35.build.flags.optimize=-Os
 teensy35.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=154
+teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=155
 teensy35.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy35.build.flags.c=
 teensy35.build.flags.S=-x assembler-with-cpp
@@ -1064,7 +1073,7 @@ teensy31.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy31.build.flags.dep=-MMD
 teensy31.build.flags.optimize=-Os
 teensy31.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=154
+teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=155
 teensy31.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy31.build.flags.c=
 teensy31.build.flags.S=-x assembler-with-cpp
@@ -1282,7 +1291,7 @@ teensy30.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy30.build.flags.dep=-MMD
 teensy30.build.flags.optimize=-Os
 teensy30.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=154
+teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=155
 teensy30.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy30.build.flags.c=
 teensy30.build.flags.S=-x assembler-with-cpp
@@ -1449,7 +1458,7 @@ teensyLC.build.command.size=arm-none-eabi-size
 teensyLC.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensyLC.build.flags.dep=-MMD
 teensyLC.build.flags.cpu=-mthumb -mcpu=cortex-m0plus -fsingle-precision-constant
-teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=154
+teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=155
 teensyLC.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensyLC.build.flags.c=
 teensyLC.build.flags.S=-x assembler-with-cpp
@@ -1612,7 +1621,7 @@ teensypp2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensypp2.build.flags.dep=-MMD
 teensypp2.build.flags.optimize=-Os
 teensypp2.build.flags.cpu=-mmcu=at90usb1286
-teensypp2.build.flags.defs=-DTEENSYDUINO=154 -DARDUINO_ARCH_AVR
+teensypp2.build.flags.defs=-DTEENSYDUINO=155 -DARDUINO_ARCH_AVR
 teensypp2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensypp2.build.flags.c=
 teensypp2.build.flags.S=-x assembler-with-cpp
@@ -1729,7 +1738,7 @@ teensy2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensy2.build.flags.dep=-MMD
 teensy2.build.flags.optimize=-Os
 teensy2.build.flags.cpu=-mmcu=atmega32u4
-teensy2.build.flags.defs=-DTEENSYDUINO=154 -DARDUINO_ARCH_AVR
+teensy2.build.flags.defs=-DTEENSYDUINO=155 -DARDUINO_ARCH_AVR
 teensy2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensy2.build.flags.c=
 teensy2.build.flags.S=-x assembler-with-cpp

--- a/hardware/teensy/avr/boards.txt
+++ b/hardware/teensy/avr/boards.txt
@@ -35,7 +35,7 @@ teensy41.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy41.build.flags.dep=-MMD
 teensy41.build.flags.optimize=-Os
 teensy41.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=155
+teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=156
 teensy41.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy41.build.flags.c=
 teensy41.build.flags.S=-x assembler-with-cpp
@@ -241,7 +241,7 @@ teensyMM.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensyMM.build.flags.dep=-MMD
 teensyMM.build.flags.optimize=-Os
 teensyMM.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=155
+teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=156
 teensyMM.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensyMM.build.flags.c=
 teensyMM.build.flags.S=-x assembler-with-cpp
@@ -447,7 +447,7 @@ teensy40.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy40.build.flags.dep=-MMD
 teensy40.build.flags.optimize=-Os
 teensy40.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=155
+teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=156
 teensy40.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy40.build.flags.c=
 teensy40.build.flags.S=-x assembler-with-cpp
@@ -649,7 +649,7 @@ teensy36.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy36.build.flags.dep=-MMD
 teensy36.build.flags.optimize=-Os
 teensy36.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=155
+teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=156
 teensy36.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy36.build.flags.c=
 teensy36.build.flags.S=-x assembler-with-cpp
@@ -866,7 +866,7 @@ teensy35.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy35.build.flags.dep=-MMD
 teensy35.build.flags.optimize=-Os
 teensy35.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=155
+teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=156
 teensy35.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy35.build.flags.c=
 teensy35.build.flags.S=-x assembler-with-cpp
@@ -1073,7 +1073,7 @@ teensy31.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy31.build.flags.dep=-MMD
 teensy31.build.flags.optimize=-Os
 teensy31.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=155
+teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=156
 teensy31.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy31.build.flags.c=
 teensy31.build.flags.S=-x assembler-with-cpp
@@ -1291,7 +1291,7 @@ teensy30.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy30.build.flags.dep=-MMD
 teensy30.build.flags.optimize=-Os
 teensy30.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=155
+teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=156
 teensy30.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy30.build.flags.c=
 teensy30.build.flags.S=-x assembler-with-cpp
@@ -1458,7 +1458,7 @@ teensyLC.build.command.size=arm-none-eabi-size
 teensyLC.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensyLC.build.flags.dep=-MMD
 teensyLC.build.flags.cpu=-mthumb -mcpu=cortex-m0plus -fsingle-precision-constant
-teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=155
+teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=156
 teensyLC.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensyLC.build.flags.c=
 teensyLC.build.flags.S=-x assembler-with-cpp
@@ -1621,7 +1621,7 @@ teensypp2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensypp2.build.flags.dep=-MMD
 teensypp2.build.flags.optimize=-Os
 teensypp2.build.flags.cpu=-mmcu=at90usb1286
-teensypp2.build.flags.defs=-DTEENSYDUINO=155 -DARDUINO_ARCH_AVR
+teensypp2.build.flags.defs=-DTEENSYDUINO=156 -DARDUINO_ARCH_AVR
 teensypp2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensypp2.build.flags.c=
 teensypp2.build.flags.S=-x assembler-with-cpp
@@ -1738,7 +1738,7 @@ teensy2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensy2.build.flags.dep=-MMD
 teensy2.build.flags.optimize=-Os
 teensy2.build.flags.cpu=-mmcu=atmega32u4
-teensy2.build.flags.defs=-DTEENSYDUINO=155 -DARDUINO_ARCH_AVR
+teensy2.build.flags.defs=-DTEENSYDUINO=156 -DARDUINO_ARCH_AVR
 teensy2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensy2.build.flags.c=
 teensy2.build.flags.S=-x assembler-with-cpp

--- a/hardware/teensy/avr/boards.txt
+++ b/hardware/teensy/avr/boards.txt
@@ -5,11 +5,10 @@ menu.keys=Keyboard Layout
 
 
 teensy41.name=Teensy 4.1
-teensy41.upload.maximum_size=8126464
+#teensy41.upload.maximum_size=8126464
 teensy41.build.board=TEENSY41
 teensy41.build.flags.ld=-Wl,--gc-sections,--relax "-T{build.core.path}/imxrt1062_t41.ld"
-teensy41.upload.maximum_data_size=524288
-#teensy41.upload.maximum_data_size=1048576
+#teensy41.upload.maximum_data_size=524288
 teensy41.upload.tool=teensyloader
 teensy41.upload.protocol=halfkay
 teensy41.build.core=teensy4
@@ -27,7 +26,7 @@ teensy41.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy41.build.flags.dep=-MMD
 teensy41.build.flags.optimize=-Os
 teensy41.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=153
+teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=154
 teensy41.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy41.build.flags.c=
 teensy41.build.flags.S=-x assembler-with-cpp
@@ -209,11 +208,212 @@ teensy41.menu.keys.usint.build.keylayout=US_INTERNATIONAL
 
 
 
+
+teensyMM.name=Teensy MicroMod
+#teensyMM.upload.maximum_size=16515072
+teensyMM.build.board=TEENSY_MICROMOD
+teensyMM.build.flags.ld=-Wl,--gc-sections,--relax "-T{build.core.path}/imxrt1062_mm.ld"
+#teensyMM.upload.maximum_data_size=524288
+#teensyMM.upload.maximum_data_size=1048576
+teensyMM.upload.tool=teensyloader
+teensyMM.upload.protocol=halfkay
+teensyMM.build.core=teensy4
+teensyMM.build.mcu=imxrt1062
+teensyMM.build.warn_data_percentage=99
+teensyMM.build.toolchain=arm/bin/
+teensyMM.build.command.gcc=arm-none-eabi-gcc
+teensyMM.build.command.g++=arm-none-eabi-g++
+teensyMM.build.command.ar=arm-none-eabi-gcc-ar
+teensyMM.build.command.objcopy=arm-none-eabi-objcopy
+teensyMM.build.command.objdump=arm-none-eabi-objdump
+teensyMM.build.command.linker=arm-none-eabi-gcc
+teensyMM.build.command.size=arm-none-eabi-size
+teensyMM.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+teensyMM.build.flags.dep=-MMD
+teensyMM.build.flags.optimize=-Os
+teensyMM.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
+teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=154
+teensyMM.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
+teensyMM.build.flags.c=
+teensyMM.build.flags.S=-x assembler-with-cpp
+teensyMM.build.flags.libs=-larm_cortexM7lfsp_math -lm -lstdc++
+teensyMM.serial.restart_cmd=false
+teensyMM.menu.usb.serial=Serial
+teensyMM.menu.usb.serial.build.usbtype=USB_SERIAL
+teensyMM.menu.usb.serial2=Dual Serial
+teensyMM.menu.usb.serial2.build.usbtype=USB_DUAL_SERIAL
+teensyMM.menu.usb.serial3=Triple Serial
+teensyMM.menu.usb.serial3.build.usbtype=USB_TRIPLE_SERIAL
+teensyMM.menu.usb.keyboard=Keyboard
+teensyMM.menu.usb.keyboard.build.usbtype=USB_KEYBOARDONLY
+teensyMM.menu.usb.keyboard.fake_serial=teensy_gateway
+teensyMM.menu.usb.touch=Keyboard + Touch Screen
+teensyMM.menu.usb.touch.build.usbtype=USB_TOUCHSCREEN
+teensyMM.menu.usb.touch.fake_serial=teensy_gateway
+teensyMM.menu.usb.hidtouch=Keyboard + Mouse + Touch Screen
+teensyMM.menu.usb.hidtouch.build.usbtype=USB_HID_TOUCHSCREEN
+teensyMM.menu.usb.hidtouch.fake_serial=teensy_gateway
+teensyMM.menu.usb.hid=Keyboard + Mouse + Joystick
+teensyMM.menu.usb.hid.build.usbtype=USB_HID
+teensyMM.menu.usb.hid.fake_serial=teensy_gateway
+teensyMM.menu.usb.serialhid=Serial + Keyboard + Mouse + Joystick
+teensyMM.menu.usb.serialhid.build.usbtype=USB_SERIAL_HID
+teensyMM.menu.usb.midi=MIDI
+teensyMM.menu.usb.midi.build.usbtype=USB_MIDI
+teensyMM.menu.usb.midi.fake_serial=teensy_gateway
+teensyMM.menu.usb.midi4=MIDIx4
+teensyMM.menu.usb.midi4.build.usbtype=USB_MIDI4
+teensyMM.menu.usb.midi4.fake_serial=teensy_gateway
+teensyMM.menu.usb.midi16=MIDIx16
+teensyMM.menu.usb.midi16.build.usbtype=USB_MIDI16
+teensyMM.menu.usb.midi16.fake_serial=teensy_gateway
+teensyMM.menu.usb.serialmidi=Serial + MIDI
+teensyMM.menu.usb.serialmidi.build.usbtype=USB_MIDI_SERIAL
+teensyMM.menu.usb.serialmidi4=Serial + MIDIx4
+teensyMM.menu.usb.serialmidi4.build.usbtype=USB_MIDI4_SERIAL
+teensyMM.menu.usb.serialmidi16=Serial + MIDIx16
+teensyMM.menu.usb.serialmidi16.build.usbtype=USB_MIDI16_SERIAL
+teensyMM.menu.usb.audio=Audio
+teensyMM.menu.usb.audio.build.usbtype=USB_AUDIO
+teensyMM.menu.usb.audio.fake_serial=teensy_gateway
+teensyMM.menu.usb.serialmidiaudio=Serial + MIDI + Audio
+teensyMM.menu.usb.serialmidiaudio.build.usbtype=USB_MIDI_AUDIO_SERIAL
+teensyMM.menu.usb.serialmidi16audio=Serial + MIDIx16 + Audio
+teensyMM.menu.usb.serialmidi16audio.build.usbtype=USB_MIDI16_AUDIO_SERIAL
+teensyMM.menu.usb.mtp=MTP Disk (Experimental)
+teensyMM.menu.usb.mtp.build.usbtype=USB_MTPDISK
+teensyMM.menu.usb.mtp.fake_serial=teensy_gateway
+teensyMM.menu.usb.rawhid=Raw HID
+teensyMM.menu.usb.rawhid.build.usbtype=USB_RAWHID
+teensyMM.menu.usb.rawhid.fake_serial=teensy_gateway
+teensyMM.menu.usb.flightsim=Flight Sim Controls
+teensyMM.menu.usb.flightsim.build.usbtype=USB_FLIGHTSIM
+teensyMM.menu.usb.flightsim.fake_serial=teensy_gateway
+teensyMM.menu.usb.flightsimjoystick=Flight Sim Controls + Joystick
+teensyMM.menu.usb.flightsimjoystick.build.usbtype=USB_FLIGHTSIM_JOYSTICK
+teensyMM.menu.usb.flightsimjoystick.fake_serial=teensy_gateway
+#teensyMM.menu.usb.disable=No USB
+#teensyMM.menu.usb.disable.build.usbtype=USB_DISABLED
+
+teensyMM.menu.speed.600=600 MHz
+teensyMM.menu.speed.528=528 MHz
+teensyMM.menu.speed.450=450 MHz
+teensyMM.menu.speed.396=396 MHz
+teensyMM.menu.speed.150=150 MHz
+teensyMM.menu.speed.24=24 MHz
+teensyMM.menu.speed.720=720 MHz (overclock)
+teensyMM.menu.speed.816=816 MHz (overclock)
+teensyMM.menu.speed.912=912 MHz (overclock, cooling req'd)
+teensyMM.menu.speed.960=960 MHz (overclock, cooling req'd)
+teensyMM.menu.speed.1008=1.008 GHz (overclock, cooling req'd)
+teensyMM.menu.speed.1008.build.fcpu=1008000000
+teensyMM.menu.speed.960.build.fcpu=960000000
+teensyMM.menu.speed.912.build.fcpu=912000000
+teensyMM.menu.speed.816.build.fcpu=816000000
+teensyMM.menu.speed.720.build.fcpu=720000000
+teensyMM.menu.speed.600.build.fcpu=600000000
+teensyMM.menu.speed.528.build.fcpu=528000000
+teensyMM.menu.speed.450.build.fcpu=450000000
+teensyMM.menu.speed.396.build.fcpu=396000000
+teensyMM.menu.speed.150.build.fcpu=150000000
+teensyMM.menu.speed.24.build.fcpu=24000000
+
+teensyMM.menu.opt.o2std=Faster
+teensyMM.menu.opt.o2std.build.flags.optimize=-O2
+teensyMM.menu.opt.o2std.build.flags.ldspecs=
+#teensyMM.menu.opt.o2lto=Faster with LTO
+#teensyMM.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
+#teensyMM.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.o1std=Fast
+teensyMM.menu.opt.o1std.build.flags.optimize=-O1
+teensyMM.menu.opt.o1std.build.flags.ldspecs=
+#teensyMM.menu.opt.o1lto=Fast with LTO
+#teensyMM.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
+#teensyMM.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.o3std=Fastest
+teensyMM.menu.opt.o3std.build.flags.optimize=-O3
+teensyMM.menu.opt.o3std.build.flags.ldspecs=
+#teensyMM.menu.opt.o3purestd=Fastest + pure-code
+#teensyMM.menu.opt.o3purestd.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__
+#teensyMM.menu.opt.o3purestd.build.flags.ldspecs=
+#teensyMM.menu.opt.o3lto=Fastest with LTO
+#teensyMM.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
+#teensyMM.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
+#teensyMM.menu.opt.o3purelto=Fastest + pure-code with LTO
+#teensyMM.menu.opt.o3purelto.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__ -flto -fno-fat-lto-objects
+#teensyMM.menu.opt.o3purelto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.ogstd=Debug
+teensyMM.menu.opt.ogstd.build.flags.optimize=-Og
+teensyMM.menu.opt.ogstd.build.flags.ldspecs=
+#teensyMM.menu.opt.oglto=Debug with LTO
+#teensyMM.menu.opt.oglto.build.flags.optimize=-Og -flto -fno-fat-lto-objects
+#teensyMM.menu.opt.oglto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.osstd=Smallest Code
+teensyMM.menu.opt.osstd.build.flags.optimize=-Os --specs=nano.specs
+teensyMM.menu.opt.osstd.build.flags.ldspecs=
+#teensyMM.menu.opt.oslto=Smallest Code with LTO
+#teensyMM.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
+#teensyMM.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
+
+teensyMM.menu.keys.en-us=US English
+teensyMM.menu.keys.en-us.build.keylayout=US_ENGLISH
+teensyMM.menu.keys.fr-ca=Canadian French
+teensyMM.menu.keys.fr-ca.build.keylayout=CANADIAN_FRENCH
+teensyMM.menu.keys.xx-ca=Canadian Multilingual
+teensyMM.menu.keys.xx-ca.build.keylayout=CANADIAN_MULTILINGUAL
+teensyMM.menu.keys.cz-cz=Czech
+teensyMM.menu.keys.cz-cz.build.keylayout=CZECH
+teensyMM.menu.keys.da-da=Danish
+teensyMM.menu.keys.da-da.build.keylayout=DANISH
+teensyMM.menu.keys.fi-fi=Finnish
+teensyMM.menu.keys.fi-fi.build.keylayout=FINNISH
+teensyMM.menu.keys.fr-fr=French
+teensyMM.menu.keys.fr-fr.build.keylayout=FRENCH
+teensyMM.menu.keys.fr-be=French Belgian
+teensyMM.menu.keys.fr-be.build.keylayout=FRENCH_BELGIAN
+teensyMM.menu.keys.fr-ch=French Swiss
+teensyMM.menu.keys.fr-ch.build.keylayout=FRENCH_SWISS
+teensyMM.menu.keys.de-de=German
+teensyMM.menu.keys.de-de.build.keylayout=GERMAN
+teensyMM.menu.keys.de-dm=German (Mac)
+teensyMM.menu.keys.de-dm.build.keylayout=GERMAN_MAC
+teensyMM.menu.keys.de-ch=German Swiss
+teensyMM.menu.keys.de-ch.build.keylayout=GERMAN_SWISS
+teensyMM.menu.keys.is-is=Icelandic
+teensyMM.menu.keys.is-is.build.keylayout=ICELANDIC
+teensyMM.menu.keys.en-ie=Irish
+teensyMM.menu.keys.en-ie.build.keylayout=IRISH
+teensyMM.menu.keys.it-it=Italian
+teensyMM.menu.keys.it-it.build.keylayout=ITALIAN
+teensyMM.menu.keys.no-no=Norwegian
+teensyMM.menu.keys.no-no.build.keylayout=NORWEGIAN
+teensyMM.menu.keys.pt-pt=Portuguese
+teensyMM.menu.keys.pt-pt.build.keylayout=PORTUGUESE
+teensyMM.menu.keys.pt-br=Portuguese Brazilian
+teensyMM.menu.keys.pt-br.build.keylayout=PORTUGUESE_BRAZILIAN
+teensyMM.menu.keys.rs-rs=Serbian (Latin Only)
+teensyMM.menu.keys.rs-rs.build.keylayout=SERBIAN_LATIN_ONLY
+teensyMM.menu.keys.es-es=Spanish
+teensyMM.menu.keys.es-es.build.keylayout=SPANISH
+teensyMM.menu.keys.es-mx=Spanish Latin America
+teensyMM.menu.keys.es-mx.build.keylayout=SPANISH_LATIN_AMERICA
+teensyMM.menu.keys.sv-se=Swedish
+teensyMM.menu.keys.sv-se.build.keylayout=SWEDISH
+teensyMM.menu.keys.tr-tr=Turkish (partial)
+teensyMM.menu.keys.tr-tr.build.keylayout=TURKISH
+teensyMM.menu.keys.en-gb=United Kingdom
+teensyMM.menu.keys.en-gb.build.keylayout=UNITED_KINGDOM
+teensyMM.menu.keys.usint=US International
+teensyMM.menu.keys.usint.build.keylayout=US_INTERNATIONAL
+
+
+
+
 teensy40.name=Teensy 4.0
-teensy40.upload.maximum_size=2031616
+#teensy40.upload.maximum_size=2031616
 teensy40.build.board=TEENSY40
 teensy40.build.flags.ld=-Wl,--gc-sections,--relax "-T{build.core.path}/imxrt1062.ld"
-teensy40.upload.maximum_data_size=524288
+#teensy40.upload.maximum_data_size=524288
 #teensy40.upload.maximum_data_size=1048576
 teensy40.upload.tool=teensyloader
 teensy40.upload.protocol=halfkay
@@ -232,7 +432,7 @@ teensy40.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy40.build.flags.dep=-MMD
 teensy40.build.flags.optimize=-Os
 teensy40.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=153
+teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=154
 teensy40.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy40.build.flags.c=
 teensy40.build.flags.S=-x assembler-with-cpp
@@ -430,11 +630,11 @@ teensy36.build.command.objcopy=arm-none-eabi-objcopy
 teensy36.build.command.objdump=arm-none-eabi-objdump
 teensy36.build.command.linker=arm-none-eabi-gcc
 teensy36.build.command.size=arm-none-eabi-size
-teensy36.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+teensy36.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensy36.build.flags.dep=-MMD
 teensy36.build.flags.optimize=-Os
 teensy36.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=153
+teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=154
 teensy36.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy36.build.flags.c=
 teensy36.build.flags.S=-x assembler-with-cpp
@@ -647,11 +847,11 @@ teensy35.build.command.objcopy=arm-none-eabi-objcopy
 teensy35.build.command.objdump=arm-none-eabi-objdump
 teensy35.build.command.linker=arm-none-eabi-gcc
 teensy35.build.command.size=arm-none-eabi-size
-teensy35.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+teensy35.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensy35.build.flags.dep=-MMD
 teensy35.build.flags.optimize=-Os
 teensy35.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=153
+teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=154
 teensy35.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy35.build.flags.c=
 teensy35.build.flags.S=-x assembler-with-cpp
@@ -854,11 +1054,11 @@ teensy31.build.command.objcopy=arm-none-eabi-objcopy
 teensy31.build.command.objdump=arm-none-eabi-objdump
 teensy31.build.command.linker=arm-none-eabi-gcc
 teensy31.build.command.size=arm-none-eabi-size
-teensy31.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+teensy31.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensy31.build.flags.dep=-MMD
 teensy31.build.flags.optimize=-Os
 teensy31.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=153
+teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=154
 teensy31.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy31.build.flags.c=
 teensy31.build.flags.S=-x assembler-with-cpp
@@ -1072,11 +1272,11 @@ teensy30.build.command.objcopy=arm-none-eabi-objcopy
 teensy30.build.command.objdump=arm-none-eabi-objdump
 teensy30.build.command.linker=arm-none-eabi-gcc
 teensy30.build.command.size=arm-none-eabi-size
-teensy30.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+teensy30.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensy30.build.flags.dep=-MMD
 teensy30.build.flags.optimize=-Os
 teensy30.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=153
+teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=154
 teensy30.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy30.build.flags.c=
 teensy30.build.flags.S=-x assembler-with-cpp
@@ -1240,10 +1440,10 @@ teensyLC.build.command.objcopy=arm-none-eabi-objcopy
 teensyLC.build.command.objdump=arm-none-eabi-objdump
 teensyLC.build.command.linker=arm-none-eabi-gcc
 teensyLC.build.command.size=arm-none-eabi-size
-teensyLC.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+teensyLC.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensyLC.build.flags.dep=-MMD
 teensyLC.build.flags.cpu=-mthumb -mcpu=cortex-m0plus -fsingle-precision-constant
-teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=153
+teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=154
 teensyLC.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensyLC.build.flags.c=
 teensyLC.build.flags.S=-x assembler-with-cpp
@@ -1406,7 +1606,7 @@ teensypp2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensypp2.build.flags.dep=-MMD
 teensypp2.build.flags.optimize=-Os
 teensypp2.build.flags.cpu=-mmcu=at90usb1286
-teensypp2.build.flags.defs=-DTEENSYDUINO=153 -DARDUINO_ARCH_AVR
+teensypp2.build.flags.defs=-DTEENSYDUINO=154 -DARDUINO_ARCH_AVR
 teensypp2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensypp2.build.flags.c=
 teensypp2.build.flags.S=-x assembler-with-cpp
@@ -1523,7 +1723,7 @@ teensy2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensy2.build.flags.dep=-MMD
 teensy2.build.flags.optimize=-Os
 teensy2.build.flags.cpu=-mmcu=atmega32u4
-teensy2.build.flags.defs=-DTEENSYDUINO=153 -DARDUINO_ARCH_AVR
+teensy2.build.flags.defs=-DTEENSYDUINO=154 -DARDUINO_ARCH_AVR
 teensy2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensy2.build.flags.c=
 teensy2.build.flags.S=-x assembler-with-cpp

--- a/hardware/teensy/avr/cores/teensy3/WProgram.h
+++ b/hardware/teensy/avr/cores/teensy3/WProgram.h
@@ -73,6 +73,7 @@
 #include "WString.h"
 #include "elapsedMillis.h"
 #include "IntervalTimer.h"
+#include "CrashReport.h"
 
 uint16_t makeWord(uint16_t w);
 uint16_t makeWord(byte h, byte l);

--- a/hardware/teensy/avr/cores/teensy3/usb_desc.c
+++ b/hardware/teensy/avr/cores/teensy3/usb_desc.c
@@ -654,7 +654,7 @@ static uint8_t flightsim_report_desc[] = {
 // **************************************************************
 
 // USB Configuration Descriptor.  This huge descriptor tells all
-// of the devices capbilities.
+// of the devices capabilities.
 static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         // configuration descriptor, USB spec 9.6.3, page 264-266, Table 9-10
         9,                                      // bLength;
@@ -927,14 +927,14 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         0x02,                                   // bDescriptorSubtype = MIDI_IN_JACK
         0x01,                                   // bJackType = EMBEDDED
         1,                                      // bJackID, ID = 1
-        0,                                      // iJack
+        0x05,                                      // iJack
         // MIDI IN Jack Descriptor, B.4.3, Table B-8 (external), page 40
         6,                                      // bLength
         0x24,                                   // bDescriptorType = CS_INTERFACE
         0x02,                                   // bDescriptorSubtype = MIDI_IN_JACK
         0x02,                                   // bJackType = EXTERNAL
         2,                                      // bJackID, ID = 2
-        0,                                      // iJack
+        0x05,                                      // iJack
         // MIDI OUT Jack Descriptor, B.4.4, Table B-9, page 41
         9,
         0x24,                                   // bDescriptorType = CS_INTERFACE
@@ -944,7 +944,7 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         1,                                      // bNrInputPins = 1 pin
         2,                                      // BaSourceID(1) = 2
         1,                                      // BaSourcePin(1) = first pin
-        0,                                      // iJack
+        0x05,                                      // iJack
         // MIDI OUT Jack Descriptor, B.4.4, Table B-10, page 41
         9,
         0x24,                                   // bDescriptorType = CS_INTERFACE
@@ -954,56 +954,56 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         1,                                      // bNrInputPins = 1 pin
         1,                                      // BaSourceID(1) = 1
         1,                                      // BaSourcePin(1) = first pin
-        0,                                      // iJack
+        0x05,                                      // iJack
   #if MIDI_NUM_CABLES >= 2
-	#define MIDI_INTERFACE_JACK_PAIR(a, b, c, d) \
-		6, 0x24, 0x02, 0x01, (a), 0, \
-		6, 0x24, 0x02, 0x02, (b), 0, \
-		9, 0x24, 0x03, 0x01, (c), 1, (b), 1, 0, \
-		9, 0x24, 0x03, 0x02, (d), 1, (a), 1, 0,
-	MIDI_INTERFACE_JACK_PAIR(5, 6, 7, 8)
+	#define MIDI_INTERFACE_JACK_PAIR(a, b, c, d, e) \
+		6, 0x24, 0x02, 0x01, (a), (e), \
+		6, 0x24, 0x02, 0x02, (b), (e), \
+		9, 0x24, 0x03, 0x01, (c), 1, (b), 1, (e), \
+		9, 0x24, 0x03, 0x02, (d), 1, (a), 1, (e),
+	MIDI_INTERFACE_JACK_PAIR(5, 6, 7, 8, 0x06)
   #endif
   #if MIDI_NUM_CABLES >= 3
-	MIDI_INTERFACE_JACK_PAIR(9, 10, 11, 12)
+	MIDI_INTERFACE_JACK_PAIR(9, 10, 11, 12, 0x07)
   #endif
   #if MIDI_NUM_CABLES >= 4
-	MIDI_INTERFACE_JACK_PAIR(13, 14, 15, 16)
+	MIDI_INTERFACE_JACK_PAIR(13, 14, 15, 16, 0x08)
   #endif
   #if MIDI_NUM_CABLES >= 5
-	MIDI_INTERFACE_JACK_PAIR(17, 18, 19, 20)
+	MIDI_INTERFACE_JACK_PAIR(17, 18, 19, 20, 0x09)
   #endif
   #if MIDI_NUM_CABLES >= 6
-	MIDI_INTERFACE_JACK_PAIR(21, 22, 23, 24)
+	MIDI_INTERFACE_JACK_PAIR(21, 22, 23, 24, 0x0A)
   #endif
   #if MIDI_NUM_CABLES >= 7
-	MIDI_INTERFACE_JACK_PAIR(25, 26, 27, 28)
+	MIDI_INTERFACE_JACK_PAIR(25, 26, 27, 28, 0x0B)
   #endif
   #if MIDI_NUM_CABLES >= 8
-	MIDI_INTERFACE_JACK_PAIR(29, 30, 31, 32)
+	MIDI_INTERFACE_JACK_PAIR(29, 30, 31, 32, 0x0C)
   #endif
   #if MIDI_NUM_CABLES >= 9
-	MIDI_INTERFACE_JACK_PAIR(33, 34, 35, 36)
+	MIDI_INTERFACE_JACK_PAIR(33, 34, 35, 36, 0x0D)
   #endif
   #if MIDI_NUM_CABLES >= 10
-	MIDI_INTERFACE_JACK_PAIR(37, 38, 39, 40)
+	MIDI_INTERFACE_JACK_PAIR(37, 38, 39, 40, 0x0E)
   #endif
   #if MIDI_NUM_CABLES >= 11
-	MIDI_INTERFACE_JACK_PAIR(41, 42, 43, 44)
+	MIDI_INTERFACE_JACK_PAIR(41, 42, 43, 44, 0x0F)
   #endif
   #if MIDI_NUM_CABLES >= 12
-	MIDI_INTERFACE_JACK_PAIR(45, 46, 47, 48)
+	MIDI_INTERFACE_JACK_PAIR(45, 46, 47, 48, 0x10)
   #endif
   #if MIDI_NUM_CABLES >= 13
-	MIDI_INTERFACE_JACK_PAIR(49, 50, 51, 52)
+	MIDI_INTERFACE_JACK_PAIR(49, 50, 51, 52, 0x11)
   #endif
   #if MIDI_NUM_CABLES >= 14
-	MIDI_INTERFACE_JACK_PAIR(53, 54, 55, 56)
+	MIDI_INTERFACE_JACK_PAIR(53, 54, 55, 56, 0x12)
   #endif
   #if MIDI_NUM_CABLES >= 15
-	MIDI_INTERFACE_JACK_PAIR(57, 58, 59, 60)
+	MIDI_INTERFACE_JACK_PAIR(57, 58, 59, 60, 0x13)
   #endif
   #if MIDI_NUM_CABLES >= 16
-	MIDI_INTERFACE_JACK_PAIR(61, 62, 63, 64)
+	MIDI_INTERFACE_JACK_PAIR(61, 62, 63, 64, 0x14)
   #endif
         // Standard Bulk OUT Endpoint Descriptor, B.5.1, Table B-11, pae 42
         9,                                      // bLength
@@ -1660,7 +1660,6 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         MULTITOUCH_SIZE, 0,                     // wMaxPacketSize
         1,                                      // bInterval
 #endif // KEYMEDIA_INTERFACE
-
 };
 
 
@@ -1687,6 +1686,71 @@ extern struct usb_string_descriptor_struct usb_string_product_name
 extern struct usb_string_descriptor_struct usb_string_serial_number
         __attribute__ ((weak, alias("usb_string_serial_number_default")));
 
+#ifdef MIDI_INTERFACE
+        extern struct usb_string_descriptor_struct usb_string_midi_port1
+                __attribute__ ((weak, alias("usb_string_midi_port1_default")));
+#if MIDI_NUM_CABLES >= 2
+        extern struct usb_string_descriptor_struct usb_string_midi_port2
+                __attribute__ ((weak, alias("usb_string_midi_port2_default")));
+#endif
+#if MIDI_NUM_CABLES >= 3
+        extern struct usb_string_descriptor_struct usb_string_midi_port3
+                __attribute__ ((weak, alias("usb_string_midi_port3_default")));
+#endif
+#if MIDI_NUM_CABLES >= 4
+        extern struct usb_string_descriptor_struct usb_string_midi_port4
+                __attribute__ ((weak, alias("usb_string_midi_port4_default")));
+#endif
+#if MIDI_NUM_CABLES >= 5
+        extern struct usb_string_descriptor_struct usb_string_midi_port5
+                __attribute__ ((weak, alias("usb_string_midi_port5_default")));
+#endif
+#if MIDI_NUM_CABLES >= 6
+        extern struct usb_string_descriptor_struct usb_string_midi_port6
+                __attribute__ ((weak, alias("usb_string_midi_port6_default")));
+#endif
+#if MIDI_NUM_CABLES >= 7
+        extern struct usb_string_descriptor_struct usb_string_midi_port7
+                __attribute__ ((weak, alias("usb_string_midi_port7_default")));
+#endif
+#if MIDI_NUM_CABLES >= 8
+        extern struct usb_string_descriptor_struct usb_string_midi_port8
+                __attribute__ ((weak, alias("usb_string_midi_port8_default")));
+#endif
+#if MIDI_NUM_CABLES >= 9
+        extern struct usb_string_descriptor_struct usb_string_midi_port9
+                __attribute__ ((weak, alias("usb_string_midi_port9_default")));
+#endif
+#if MIDI_NUM_CABLES >= 10
+        extern struct usb_string_descriptor_struct usb_string_midi_port10
+                __attribute__ ((weak, alias("usb_string_midi_port10_default")));
+#endif
+#if MIDI_NUM_CABLES >= 11
+        extern struct usb_string_descriptor_struct usb_string_midi_port11
+                __attribute__ ((weak, alias("usb_string_midi_port11_default")));
+#endif
+#if MIDI_NUM_CABLES >= 12
+        extern struct usb_string_descriptor_struct usb_string_midi_port12
+                __attribute__ ((weak, alias("usb_string_midi_port12_default")));
+#endif
+#if MIDI_NUM_CABLES >= 13
+        extern struct usb_string_descriptor_struct usb_string_midi_port13
+                __attribute__ ((weak, alias("usb_string_midi_port13_default")));
+#endif
+#if MIDI_NUM_CABLES >= 14
+        extern struct usb_string_descriptor_struct usb_string_midi_port14
+                __attribute__ ((weak, alias("usb_string_midi_port14_default")));
+#endif
+#if MIDI_NUM_CABLES >= 15
+        extern struct usb_string_descriptor_struct usb_string_midi_port15
+                __attribute__ ((weak, alias("usb_string_midi_port15_default")));
+#endif
+#if MIDI_NUM_CABLES >= 16
+        extern struct usb_string_descriptor_struct usb_string_midi_port16
+                __attribute__ ((weak, alias("usb_string_midi_port16_default")));
+#endif
+#endif
+
 struct usb_string_descriptor_struct string0 = {
         4,
         3,
@@ -1708,6 +1772,119 @@ struct usb_string_descriptor_struct usb_string_serial_number_default = {
         3,
         {0,0,0,0,0,0,0,0,0,0}
 };
+#ifdef MIDI_INTERFACE
+        struct usb_string_descriptor_struct usb_string_midi_port1_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','1'}
+        };
+#if MIDI_NUM_CABLES >= 2
+        struct usb_string_descriptor_struct usb_string_midi_port2_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','2'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 3
+        struct usb_string_descriptor_struct usb_string_midi_port3_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','3'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 4
+        struct usb_string_descriptor_struct usb_string_midi_port4_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','4'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 5
+        struct usb_string_descriptor_struct usb_string_midi_port5_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','5'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 6
+        struct usb_string_descriptor_struct usb_string_midi_port6_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','6'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 7
+        struct usb_string_descriptor_struct usb_string_midi_port7_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','7'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 8
+        struct usb_string_descriptor_struct usb_string_midi_port8_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','8'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 9
+        struct usb_string_descriptor_struct usb_string_midi_port9_default = {
+                14,
+                3,
+                {'P','o','r','t',' ','9'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 10
+        struct usb_string_descriptor_struct usb_string_midi_port10_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','0'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 11
+        struct usb_string_descriptor_struct usb_string_midi_port11_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','1'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 12
+        struct usb_string_descriptor_struct usb_string_midi_port12_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','2'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 13
+        struct usb_string_descriptor_struct usb_string_midi_port13_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','3'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 14
+        struct usb_string_descriptor_struct usb_string_midi_port14_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','4'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 15
+        struct usb_string_descriptor_struct usb_string_midi_port15_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','5'}
+        };
+#endif
+#if MIDI_NUM_CABLES >= 16
+        struct usb_string_descriptor_struct usb_string_midi_port16_default = {
+                16,
+                3,
+                {'P','o','r','t',' ','1','6'}
+        };
+#endif
+#endif
+
 #ifdef MTP_INTERFACE
 struct usb_string_descriptor_struct usb_string_mtp = {
 	2 + 3 * 2,
@@ -1799,6 +1976,54 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
 #endif
 #ifdef MTP_INTERFACE
 	{0x0304, 0x0409, (const uint8_t *)&usb_string_mtp, 0},
+#endif
+#ifdef MIDI_INTERFACE
+	{0x0305, 0x0409, (const uint8_t *)&usb_string_midi_port1, 0},
+#if MIDI_NUM_CABLES >= 2
+	{0x0306, 0x0409, (const uint8_t *)&usb_string_midi_port2, 0},
+#endif
+#if MIDI_NUM_CABLES >= 3
+	{0x0307, 0x0409, (const uint8_t *)&usb_string_midi_port3, 0},
+#endif
+#if MIDI_NUM_CABLES >= 4
+	{0x0308, 0x0409, (const uint8_t *)&usb_string_midi_port4, 0},
+#endif
+#if MIDI_NUM_CABLES >= 5
+	{0x0309, 0x0409, (const uint8_t *)&usb_string_midi_port5, 0},
+#endif
+#if MIDI_NUM_CABLES >= 6
+	{0x030A, 0x0409, (const uint8_t *)&usb_string_midi_port6, 0},
+#endif
+#if MIDI_NUM_CABLES >= 7
+	{0x030B, 0x0409, (const uint8_t *)&usb_string_midi_port7, 0},
+#endif
+#if MIDI_NUM_CABLES >= 8
+	{0x030C, 0x0409, (const uint8_t *)&usb_string_midi_port8, 0},
+#endif
+#if MIDI_NUM_CABLES >= 9
+	{0x030D, 0x0409, (const uint8_t *)&usb_string_midi_port9, 0},
+#endif
+#if MIDI_NUM_CABLES >= 10
+	{0x030E, 0x0409, (const uint8_t *)&usb_string_midi_port10, 0},
+#endif
+#if MIDI_NUM_CABLES >= 11
+	{0x030F, 0x0409, (const uint8_t *)&usb_string_midi_port11, 0},
+#endif
+#if MIDI_NUM_CABLES >= 12
+	{0x0310, 0x0409, (const uint8_t *)&usb_string_midi_port12, 0},
+#endif
+#if MIDI_NUM_CABLES >= 13
+	{0x0311, 0x0409, (const uint8_t *)&usb_string_midi_port13, 0},
+#endif
+#if MIDI_NUM_CABLES >= 14
+	{0x0312, 0x0409, (const uint8_t *)&usb_string_midi_port14, 0},
+#endif
+#if MIDI_NUM_CABLES >= 15
+	{0x0313, 0x0409, (const uint8_t *)&usb_string_midi_port15, 0},
+#endif
+#if MIDI_NUM_CABLES >= 16
+	{0x0314, 0x0409, (const uint8_t *)&usb_string_midi_port16, 0},
+#endif
 #endif
         {0x0300, 0x0000, (const uint8_t *)&string0, 0},
         {0x0301, 0x0409, (const uint8_t *)&usb_string_manufacturer_name, 0},

--- a/hardware/teensy/avr/cores/teensy3/usb_desc.c
+++ b/hardware/teensy/avr/cores/teensy3/usb_desc.c
@@ -1360,7 +1360,7 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         0x06,                                   // bInterfaceClass (0x06 = still image)
         0x01,                                   // bInterfaceSubClass
         0x01,                                   // bInterfaceProtocol
-        0,                                      // iInterface
+        4,                                      // iInterface
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         7,                                      // bLength
         5,                                      // bDescriptorType

--- a/hardware/teensy/avr/cores/teensy3/usb_desc.h
+++ b/hardware/teensy/avr/cores/teensy3/usb_desc.h
@@ -792,7 +792,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MTP_RX_ENDPOINT	3
   #define MTP_RX_SIZE		64
   #define MTP_EVENT_ENDPOINT	4
-  #define MTP_EVENT_SIZE	16
+  #define MTP_EVENT_SIZE	32
   #define MTP_EVENT_INTERVAL	10
   #define SEREMU_INTERFACE      1	// Serial emulation
   #define SEREMU_TX_ENDPOINT    1
@@ -804,8 +804,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define ENDPOINT1_CONFIG	ENDPOINT_TRANSMIT_ONLY
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_ONLY
   #define ENDPOINT3_CONFIG	ENDPOINT_TRANSMIT_AND_RECEIVE
-  // TODO: Should ENDPOINT4_CONFIG be ENDPOINT_TRANSMIT_ONLY ???
-  #define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_ONLY
+  #define ENDPOINT4_CONFIG	ENDPOINT_TRANSMIT_AND_RECEIVE
 
 #elif defined(USB_AUDIO)
   #define VENDOR_ID		0x16C0

--- a/hardware/teensy/avr/cores/teensy3/usb_inst.cpp
+++ b/hardware/teensy/avr/cores/teensy3/usb_inst.cpp
@@ -82,6 +82,7 @@ uint8_t usb_joystick_class::manual_mode = 0;
 
 #ifdef NSGAMEPAD_INTERFACE
 usb_nsgamepad_class NSGamepad;
+usb_serial_class Serial;  // dummy
 #endif
 
 #ifdef USB_DISABLED

--- a/hardware/teensy/avr/cores/teensy3/usb_serial.h
+++ b/hardware/teensy/avr/cores/teensy3/usb_serial.h
@@ -1,0 +1,176 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef USBserial_h_
+#define USBserial_h_
+
+#include "usb_desc.h"
+
+#if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
+
+#include <inttypes.h>
+
+#if F_CPU >= 20000000 && !defined(USB_DISABLED)
+
+#include "core_pins.h" // for millis()
+
+// C language implementation
+#ifdef __cplusplus
+extern "C" {
+#endif
+int usb_serial_getchar(void);
+int usb_serial_peekchar(void);
+int usb_serial_available(void);
+int usb_serial_read(void *buffer, uint32_t size);
+void usb_serial_flush_input(void);
+int usb_serial_putchar(uint8_t c);
+int usb_serial_write(const void *buffer, uint32_t size);
+int usb_serial_write_buffer_free(void);
+void usb_serial_flush_output(void);
+void usb_serial_flush_callback(void);
+extern uint32_t usb_cdc_line_coding[2];
+extern volatile uint32_t usb_cdc_line_rtsdtr_millis;
+extern volatile uint32_t systick_millis_count;
+extern volatile uint8_t usb_cdc_line_rtsdtr;
+extern volatile uint8_t usb_cdc_transmit_flush_timer;
+extern volatile uint8_t usb_configuration;
+#ifdef __cplusplus
+}
+#endif
+
+#define USB_SERIAL_DTR  0x01
+#define USB_SERIAL_RTS  0x02
+
+// C++ interface
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial_class : public Stream
+{
+public:
+	constexpr usb_serial_class() {}
+        void begin(long) {
+		uint32_t millis_begin = systick_millis_count;
+		while (!(*this)) {
+			uint32_t elapsed = systick_millis_count - millis_begin;
+			if (usb_configuration) {
+				// Wait up to 2 seconds for Arduino Serial Monitor
+				if (elapsed > 2000) break;
+			} else {
+				// But wait only 3/4 second if there is no sign the
+				// USB host has begun the USB enumeration process.
+				if (elapsed > 750) break;
+			}
+		}
+	}
+        void end() { /* TODO: flush output and shut down USB port */ };
+        virtual int available() { return usb_serial_available(); }
+        virtual int read() { return usb_serial_getchar(); }
+        virtual int peek() { return usb_serial_peekchar(); }
+        virtual void flush() { usb_serial_flush_output(); }  // TODO: actually wait for data to leave USB...
+        virtual void clear(void) { usb_serial_flush_input(); }
+        virtual size_t write(uint8_t c) { return usb_serial_putchar(c); }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return usb_serial_write(buffer, size); }
+	size_t write(unsigned long n) { return write((uint8_t)n); }
+	size_t write(long n) { return write((uint8_t)n); }
+	size_t write(unsigned int n) { return write((uint8_t)n); }
+	size_t write(int n) { return write((uint8_t)n); }
+	virtual int availableForWrite() { return usb_serial_write_buffer_free(); }
+	using Print::write;
+        void send_now(void) { usb_serial_flush_output(); }
+        uint32_t baud(void) { return usb_cdc_line_coding[0]; }
+        uint8_t stopbits(void) { uint8_t b = usb_cdc_line_coding[1]; if (!b) b = 1; return b; }
+        uint8_t paritytype(void) { return usb_cdc_line_coding[1] >> 8; } // 0=none, 1=odd, 2=even
+        uint8_t numbits(void) { return usb_cdc_line_coding[1] >> 16; }
+        uint8_t dtr(void) { return (usb_cdc_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
+        uint8_t rts(void) { return (usb_cdc_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
+        operator bool() { return usb_configuration && (usb_cdc_line_rtsdtr & USB_SERIAL_DTR) &&
+		((uint32_t)(systick_millis_count - usb_cdc_line_rtsdtr_millis) >= 15);
+	}
+	size_t readBytes(char *buffer, size_t length) {
+		size_t count=0;
+		unsigned long startMillis = millis();
+		do {
+			count += usb_serial_read(buffer + count, length - count);
+			if (count >= length) return count;
+		} while(millis() - startMillis < _timeout);
+		setReadError();
+		return count;
+	}
+
+};
+extern usb_serial_class Serial;
+extern void serialEvent(void);
+#endif // __cplusplus
+
+
+#else  // F_CPU < 20000000
+
+// Allow Arduino programs using Serial to compile, but Serial will do nothing.
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial_class : public Stream
+{
+public:
+	constexpr usb_serial_class() {}
+        void begin(long) { };
+        void end() { };
+        virtual int available() { return 0; }
+        virtual int read() { return -1; }
+        virtual int peek() { return -1; }
+        virtual void flush() { }
+        virtual void clear() { }
+        virtual size_t write(uint8_t c) { return 1; }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return size; }
+	size_t write(unsigned long n) { return 1; }
+	size_t write(long n) { return 1; }
+	size_t write(unsigned int n) { return 1; }
+	size_t write(int n) { return 1; }
+	int availableForWrite() { return 0; }
+	using Print::write;
+        void send_now(void) { }
+        uint32_t baud(void) { return 0; }
+        uint8_t stopbits(void) { return 1; }
+        uint8_t paritytype(void) { return 0; }
+        uint8_t numbits(void) { return 8; }
+        uint8_t dtr(void) { return 1; }
+        uint8_t rts(void) { return 1; }
+        operator bool() { return true; }
+};
+
+extern usb_serial_class Serial;
+extern void serialEvent(void);
+#endif // __cplusplus
+
+
+#endif // F_CPU
+
+#endif // CDC_STATUS_INTERFACE && CDC_DATA_INTERFACE
+
+#endif // USBserial_h_

--- a/hardware/teensy/avr/cores/teensy3/usb_serial.h
+++ b/hardware/teensy/avr/cores/teensy3/usb_serial.h
@@ -33,11 +33,11 @@
 
 #include "usb_desc.h"
 
-#if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
+#if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED) || defined(USB_NSGAMEPAD)
 
 #include <inttypes.h>
 
-#if F_CPU >= 20000000 && !defined(USB_DISABLED)
+#if F_CPU >= 20000000 && !(defined(USB_DISABLED) || defined(USB_NSGAMEPAD))
 
 #include "core_pins.h" // for millis()
 

--- a/hardware/teensy/avr/cores/teensy4/WProgram.h
+++ b/hardware/teensy/avr/cores/teensy4/WProgram.h
@@ -66,6 +66,7 @@
 #include "WString.h"
 #include "elapsedMillis.h"
 #include "IntervalTimer.h"
+#include "CrashReport.h"
 
 uint16_t makeWord(uint16_t w);
 uint16_t makeWord(byte h, byte l);

--- a/hardware/teensy/avr/cores/teensy4/usb.c
+++ b/hardware/teensy/avr/cores/teensy4/usb.c
@@ -63,7 +63,7 @@ struct endpoint_struct {
 uint8_t experimental_buffer[1152] __attribute__ ((section(".dmabuffers"), aligned(64)));
 #endif
 
-endpoint_t endpoint_queue_head[(NUM_ENDPOINTS+1)*2] __attribute__ ((used, aligned(4096)));
+endpoint_t endpoint_queue_head[(NUM_ENDPOINTS+1)*2] __attribute__ ((used, aligned(4096), section(".endpoint_queue") ));
 
 transfer_t endpoint0_transfer_data __attribute__ ((used, aligned(32)));
 transfer_t endpoint0_transfer_ack  __attribute__ ((used, aligned(32)));
@@ -924,6 +924,10 @@ static void schedule_transfer(endpoint_t *endpoint, uint32_t epmask, transfer_t 
 		//USB1_USBCMD &= ~USB_USBCMD_ATDTW;
 		if (status & epmask) goto end;
 		//ret |= 0x02;
+		endpoint->next = (uint32_t)transfer;
+		endpoint->status = 0;
+		USB1_ENDPTPRIME |= epmask;
+		goto end;
 	}
 	//digitalWriteFast(4, HIGH);
 	endpoint->next = (uint32_t)transfer;

--- a/hardware/teensy/avr/cores/teensy4/usb.c
+++ b/hardware/teensy/avr/cores/teensy4/usb.c
@@ -822,6 +822,9 @@ static void endpoint0_complete(void)
 		usb_audio_set_feature(&endpoint0_setupdata, endpoint0_buffer);
 	}
 #endif
+#ifdef NSGAMEPAD_INTERFACE
+	(void) setup;  // avoid GCC "set but unused" warning
+#endif
 }
 
 static void usb_endpoint_config(endpoint_t *qh, uint32_t config, void (*callback)(transfer_t *))

--- a/hardware/teensy/avr/cores/teensy4/usb_desc.c
+++ b/hardware/teensy/avr/cores/teensy4/usb_desc.c
@@ -1423,7 +1423,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
         0x06,                                   // bInterfaceClass (0x06 = still image)
         0x01,                                   // bInterfaceSubClass
         0x01,                                   // bInterfaceProtocol
-        0,                                      // iInterface
+        4,                                      // iInterface
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         7,                                      // bLength
         5,                                      // bDescriptorType

--- a/hardware/teensy/avr/cores/teensy4/usb_desc.c
+++ b/hardware/teensy/avr/cores/teensy4/usb_desc.c
@@ -72,6 +72,19 @@
 #define LSB(n) ((n) & 255)
 #define MSB(n) (((n) >> 8) & 255)
 
+#ifdef CDC_IAD_DESCRIPTOR
+#ifndef DEVICE_CLASS
+#define DEVICE_CLASS 0xEF
+#endif
+#ifndef DEVICE_SUBCLASS
+#define DEVICE_SUBCLASS 0x02
+#endif
+#ifndef DEVICE_PROTOCOL
+#define DEVICE_PROTOCOL 0x01
+#endif
+#endif
+
+
 // USB Device Descriptor.  The USB host reads this first, to learn
 // what type of device is connected.
 static uint8_t device_descriptor[] = {
@@ -106,6 +119,8 @@ static uint8_t device_descriptor[] = {
         0x79, 0x02, // Teensy 4.0
   #elif defined(__IMXRT1062__) && defined(ARDUINO_TEENSY41)
         0x80, 0x02, // Teensy 4.1
+  #elif defined(__IMXRT1062__) && defined(ARDUINO_TEENSY_MICROMOD)
+        0x81, 0x02, // Teensy MicroMod
   #else
         0x00, 0x02,
   #endif
@@ -672,7 +687,15 @@ static uint8_t flightsim_report_desc[] = {
 #define MULTITOUCH_INTERFACE_DESC_SIZE	0
 #endif
 
-#define CONFIG_DESC_SIZE		MULTITOUCH_INTERFACE_DESC_POS+MULTITOUCH_INTERFACE_DESC_SIZE
+#define EXPERIMENTAL_INTERFACE_DESC_POS	MULTITOUCH_INTERFACE_DESC_POS+MULTITOUCH_INTERFACE_DESC_SIZE
+#ifdef  EXPERIMENTAL_INTERFACE
+#define EXPERIMENTAL_INTERFACE_DESC_SIZE 9+7+7
+#define EXPERIMENTAL_HID_DESC_OFFSET	MULTITOUCH_INTERFACE_DESC_POS+9
+#else
+#define EXPERIMENTAL_INTERFACE_DESC_SIZE 0
+#endif
+
+#define CONFIG_DESC_SIZE		EXPERIMENTAL_INTERFACE_DESC_POS+EXPERIMENTAL_INTERFACE_DESC_SIZE
 
 
 
@@ -681,7 +704,7 @@ static uint8_t flightsim_report_desc[] = {
 // **************************************************************
 
 // USB Configuration Descriptor.  This huge descriptor tells all
-// of the devices capbilities.
+// of the devices capabilities.
 
 PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
         // configuration descriptor, USB spec 9.6.3, page 264-266, Table 9-10
@@ -1702,7 +1725,35 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
         0x03,                                   // bmAttributes (0x03=intr)
         MULTITOUCH_SIZE, 0,                     // wMaxPacketSize
         4,                                      // bInterval, 4 = 1ms
-#endif // KEYMEDIA_INTERFACE
+#endif // MULTITOUCH_INTERFACE
+
+#ifdef EXPERIMENTAL_INTERFACE
+	// configuration for 480 Mbit/sec speed
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        9,                                      // bLength
+        4,                                      // bDescriptorType
+        EXPERIMENTAL_INTERFACE,                 // bInterfaceNumber
+        0,                                      // bAlternateSetting
+        2,                                      // bNumEndpoints
+        0xFF,                                   // bInterfaceClass (0xFF = Vendor)
+        0x6A,                                   // bInterfaceSubClass
+        0xFF,                                   // bInterfaceProtocol
+        0,                                      // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        7,                                      // bLength
+        5,                                      // bDescriptorType
+        1 | 0x80,                               // bEndpointAddress
+        0x02,                                   // bmAttributes (0x02=bulk)
+        LSB(512), MSB(512),                     // wMaxPacketSize
+        1,                                      // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        7,                                      // bLength
+        5,                                      // bDescriptorType
+        1,                                      // bEndpointAddress
+        0x02,                                   // bmAttributes (0x02=bulk)
+        LSB(512), MSB(512),                     // wMaxPacketSize
+        1,                                      // bInterval
+#endif // EXPERIMENTAL_INTERFACE
 };
 
 
@@ -2717,7 +2768,35 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
         0x03,                                   // bmAttributes (0x03=intr)
         MULTITOUCH_SIZE, 0,                     // wMaxPacketSize
         1,                                      // bInterval
-#endif // KEYMEDIA_INTERFACE
+#endif // MULTITOUCH_INTERFACE
+
+#ifdef EXPERIMENTAL_INTERFACE
+	// configuration for 12 Mbit/sec speed
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        9,                                      // bLength
+        4,                                      // bDescriptorType
+        EXPERIMENTAL_INTERFACE,                 // bInterfaceNumber
+        0,                                      // bAlternateSetting
+        2,                                      // bNumEndpoints
+        0xFF,                                   // bInterfaceClass (0xFF = Vendor)
+        0x6A,                                   // bInterfaceSubClass
+        0xFF,                                   // bInterfaceProtocol
+        0,                                      // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        7,                                      // bLength
+        5,                                      // bDescriptorType
+        1 | 0x80,                               // bEndpointAddress
+        0x02,                                   // bmAttributes (0x02=bulk)
+        LSB(64), MSB(64),                       // wMaxPacketSize
+        1,                                      // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        7,                                      // bLength
+        5,                                      // bDescriptorType
+        1,                                      // bEndpointAddress
+        0x02,                                   // bmAttributes (0x02=bulk)
+        LSB(64), MSB(64),                       // wMaxPacketSize
+        1,                                      // bInterval
+#endif // EXPERIMENTAL_INTERFACE
 };
 
 

--- a/hardware/teensy/avr/cores/teensy4/usb_desc.h
+++ b/hardware/teensy/avr/cores/teensy4/usb_desc.h
@@ -114,7 +114,6 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
 #if defined(USB_SERIAL)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x0483
-  #define DEVICE_CLASS		2	// 2 = Communication Class
   #define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
   #define MANUFACTURER_NAME_LEN	11
   #define PRODUCT_NAME		{'U','S','B',' ','S','e','r','i','a','l'}
@@ -123,6 +122,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define NUM_ENDPOINTS		4
   #define NUM_USB_BUFFERS	12
   #define NUM_INTERFACE		2
+  #define CDC_IAD_DESCRIPTOR    1       // Serial
   #define CDC_STATUS_INTERFACE	0
   #define CDC_DATA_INTERFACE	1
   #define CDC_ACM_ENDPOINT	2
@@ -133,6 +133,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define CDC_TX_SIZE_480       512
   #define CDC_RX_SIZE_12        64
   #define CDC_TX_SIZE_12        64
+  //#define EXPERIMENTAL_INTERFACE 2
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_UNUSED
   #define ENDPOINT4_CONFIG      ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_BULK
@@ -797,7 +798,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MTP_RX_SIZE_12	64
   #define MTP_RX_SIZE_480	512
   #define MTP_EVENT_ENDPOINT	4
-  #define MTP_EVENT_SIZE	16
+  #define MTP_EVENT_SIZE	32
   #define MTP_EVENT_INTERVAL_12	10	// 10 = 10 ms
   #define MTP_EVENT_INTERVAL_480 7	// 7 = 8 ms
   #define SEREMU_INTERFACE      1	// Serial emulation
@@ -809,8 +810,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define SEREMU_RX_INTERVAL    2
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
-  // TODO: Should ENDPOINT4_CONFIG be ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT ???
-  #define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_UNUSED
+  #define ENDPOINT4_CONFIG  ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
 
 #elif defined(USB_AUDIO)
   #define VENDOR_ID		0x16C0

--- a/hardware/teensy/avr/cores/teensy4/usb_desc.h
+++ b/hardware/teensy/avr/cores/teensy4/usb_desc.h
@@ -790,7 +790,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define EP0_SIZE		64
   #define NUM_ENDPOINTS         4
   #define NUM_INTERFACE		2
-  #define MTP_INTERFACE		0	// MTP Disk
+  #define MTP_INTERFACE		1	// MTP Disk
   #define MTP_TX_ENDPOINT	3
   #define MTP_TX_SIZE_12	64
   #define MTP_TX_SIZE_480	512
@@ -801,7 +801,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MTP_EVENT_SIZE	32
   #define MTP_EVENT_INTERVAL_12	10	// 10 = 10 ms
   #define MTP_EVENT_INTERVAL_480 7	// 7 = 8 ms
-  #define SEREMU_INTERFACE      1	// Serial emulation
+  #define SEREMU_INTERFACE      0	// Serial emulation
   #define SEREMU_TX_ENDPOINT    2
   #define SEREMU_TX_SIZE        64
   #define SEREMU_TX_INTERVAL    1

--- a/hardware/teensy/avr/cores/teensy4/usb_inst.cpp
+++ b/hardware/teensy/avr/cores/teensy4/usb_inst.cpp
@@ -82,6 +82,7 @@ uint8_t usb_joystick_class::manual_mode = 0;
 
 #ifdef NSGAMEPAD_INTERFACE
 usb_nsgamepad_class NSGamepad;
+usb_serial_class Serial;  // dummy
 #endif
 
 #ifdef USB_DISABLED

--- a/hardware/teensy/avr/cores/teensy4/usb_inst.cpp
+++ b/hardware/teensy/avr/cores/teensy4/usb_inst.cpp
@@ -100,3 +100,4 @@ usb_seremu_class Serial;
 #endif
 
 #endif // F_CPU
+

--- a/hardware/teensy/avr/cores/teensy4/usb_serial.h
+++ b/hardware/teensy/avr/cores/teensy4/usb_serial.h
@@ -1,0 +1,351 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "usb_desc.h"
+#include <stdint.h>
+
+#if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
+
+#if !defined(USB_DISABLED)
+
+// C language implementation
+#ifdef __cplusplus
+extern "C" {
+#endif
+void usb_serial_reset(void);
+void usb_serial_configure(void);
+int usb_serial_getchar(void);
+int usb_serial_peekchar(void);
+int usb_serial_available(void);
+int usb_serial_read(void *buffer, uint32_t size);
+void usb_serial_flush_input(void);
+int usb_serial_putchar(uint8_t c);
+int usb_serial_write(const void *buffer, uint32_t size);
+int usb_serial_write_buffer_free(void);
+void usb_serial_flush_output(void);
+extern uint32_t usb_cdc_line_coding[2];
+extern volatile uint32_t usb_cdc_line_rtsdtr_millis;
+extern volatile uint32_t systick_millis_count;
+extern volatile uint8_t usb_cdc_line_rtsdtr;
+extern volatile uint8_t usb_cdc_transmit_flush_timer;
+extern volatile uint8_t usb_configuration;
+#ifdef __cplusplus
+}
+#endif
+
+#define USB_SERIAL_DTR  0x01
+#define USB_SERIAL_RTS  0x02
+
+// C++ interface
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial_class : public Stream
+{
+public:
+	constexpr usb_serial_class() {}
+        void begin(long) {
+		uint32_t millis_begin = systick_millis_count;
+		while (!(*this)) {
+			uint32_t elapsed = systick_millis_count - millis_begin;
+			if (usb_configuration) {
+				// Wait up to 2 seconds for Arduino Serial Monitor
+				if (elapsed > 2000) break;
+			} else {
+				// But wait only 3/4 second if there is no sign the
+				// USB host has begun the USB enumeration process.
+				if (elapsed > 750) break;
+			}
+		}
+	}
+        void end() { /* TODO: flush output and shut down USB port */ };
+        virtual int available() { return usb_serial_available(); }
+        virtual int read() { return usb_serial_getchar(); }
+        virtual int peek() { return usb_serial_peekchar(); }
+        virtual void flush() { usb_serial_flush_output(); }  // TODO: actually wait for data to leave USB...
+        virtual void clear(void) { usb_serial_flush_input(); }
+        virtual size_t write(uint8_t c) { return usb_serial_putchar(c); }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return usb_serial_write(buffer, size); }
+	size_t write(unsigned long n) { return write((uint8_t)n); }
+	size_t write(long n) { return write((uint8_t)n); }
+	size_t write(unsigned int n) { return write((uint8_t)n); }
+	size_t write(int n) { return write((uint8_t)n); }
+	virtual int availableForWrite() { return usb_serial_write_buffer_free(); }
+	using Print::write;
+        void send_now(void) { usb_serial_flush_output(); }
+        uint32_t baud(void) { return usb_cdc_line_coding[0]; }
+        uint8_t stopbits(void) { uint8_t b = usb_cdc_line_coding[1]; if (!b) b = 1; return b; }
+        uint8_t paritytype(void) { return usb_cdc_line_coding[1] >> 8; } // 0=none, 1=odd, 2=even
+        uint8_t numbits(void) { return usb_cdc_line_coding[1] >> 16; }
+        uint8_t dtr(void) { return (usb_cdc_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
+        uint8_t rts(void) { return (usb_cdc_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
+        operator bool() { return usb_configuration && (usb_cdc_line_rtsdtr & USB_SERIAL_DTR) &&
+		((uint32_t)(systick_millis_count - usb_cdc_line_rtsdtr_millis) >= 15);
+	}
+	size_t readBytes(char *buffer, size_t length) {
+		size_t count=0;
+		unsigned long startMillis = millis();
+		do {
+			count += usb_serial_read(buffer + count, length - count);
+			if (count >= length) return count;
+		} while(millis() - startMillis < _timeout);
+		setReadError();
+		return count;
+	}
+
+};
+extern usb_serial_class Serial;
+extern void serialEvent(void);
+#endif // __cplusplus
+
+#else  // !defined(USB_DISABLED)
+
+// Allow Arduino programs using Serial to compile, but Serial will do nothing.
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial_class : public Stream
+{
+public:
+    constexpr usb_serial_class() {}
+        void begin(long) { };
+        void end() { };
+        virtual int available() { return 0; }
+        virtual int read() { return -1; }
+        virtual int peek() { return -1; }
+        virtual void flush() { }
+        virtual void clear() { }
+        virtual size_t write(uint8_t c) { return 1; }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return size; }
+    size_t write(unsigned long n) { return 1; }
+    size_t write(long n) { return 1; }
+    size_t write(unsigned int n) { return 1; }
+    size_t write(int n) { return 1; }
+    int availableForWrite() { return 0; }
+    using Print::write;
+        void send_now(void) { }
+        uint32_t baud(void) { return 0; }
+        uint8_t stopbits(void) { return 1; }
+        uint8_t paritytype(void) { return 0; }
+        uint8_t numbits(void) { return 8; }
+        uint8_t dtr(void) { return 1; }
+        uint8_t rts(void) { return 1; }
+        operator bool() { return true; }
+};
+
+extern usb_serial_class Serial;
+extern void serialEvent(void);
+#endif // __cplusplus
+
+#endif // !defined(USB_DISABLED)
+
+#endif // CDC_STATUS_INTERFACE && CDC_DATA_INTERFACE
+
+
+
+
+#if defined(CDC2_STATUS_INTERFACE) && defined(CDC2_DATA_INTERFACE)
+
+// C language implementation
+#ifdef __cplusplus
+extern "C" {
+#endif
+void usb_serial2_configure(void);
+int usb_serial2_getchar(void);
+int usb_serial2_peekchar(void);
+int usb_serial2_available(void);
+int usb_serial2_read(void *buffer, uint32_t size);
+void usb_serial2_flush_input(void);
+int usb_serial2_putchar(uint8_t c);
+int usb_serial2_write(const void *buffer, uint32_t size);
+int usb_serial2_write_buffer_free(void);
+void usb_serial2_flush_output(void);
+extern uint32_t usb_cdc2_line_coding[2];
+extern volatile uint32_t usb_cdc2_line_rtsdtr_millis;
+extern volatile uint8_t usb_cdc2_line_rtsdtr;
+extern volatile uint8_t usb_cdc2_transmit_flush_timer;
+#ifdef __cplusplus
+}
+#endif
+
+// C++ interface
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial2_class : public Stream
+{
+public:
+        constexpr usb_serial2_class() {}
+        void begin(long) {
+                //uint32_t millis_begin = systick_millis_count;
+                //disabled for now - causes more trouble than it solves?
+                //while (!(*this)) {
+                        // wait up to 2.5 seconds for Arduino Serial Monitor
+                        // Yes, this is a long time, but some Windows systems open
+                        // the port very slowly.  This wait allows programs for
+                        // Arduino Uno to "just work" (without forcing a reboot when
+                        // the port is opened), and when no PC is connected the user's
+                        // sketch still gets to run normally after this wait time.
+                        //if ((uint32_t)(systick_millis_count - millis_begin) > 2500) break;
+                //}
+        }
+        void end() { /* TODO: flush output and shut down USB port */ };
+        virtual int available() { return usb_serial2_available(); }
+        virtual int read() { return usb_serial2_getchar(); }
+        virtual int peek() { return usb_serial2_peekchar(); }
+        virtual void flush() { usb_serial2_flush_output(); }  // TODO: actually wait for data to leave USB...
+        virtual void clear(void) { usb_serial2_flush_input(); }
+        virtual size_t write(uint8_t c) { return usb_serial2_putchar(c); }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return usb_serial2_write(buffer, size); }
+        size_t write(unsigned long n) { return write((uint8_t)n); }
+        size_t write(long n) { return write((uint8_t)n); }
+        size_t write(unsigned int n) { return write((uint8_t)n); }
+        size_t write(int n) { return write((uint8_t)n); }
+        virtual int availableForWrite() { return usb_serial2_write_buffer_free(); }
+        using Print::write;
+        void send_now(void) { usb_serial2_flush_output(); }
+        uint32_t baud(void) { return usb_cdc2_line_coding[0]; }
+        uint8_t stopbits(void) { uint8_t b = usb_cdc2_line_coding[1]; if (!b) b = 1; return b; }
+        uint8_t paritytype(void) { return usb_cdc2_line_coding[1] >> 8; } // 0=none, 1=odd, 2=even
+        uint8_t numbits(void) { return usb_cdc2_line_coding[1] >> 16; }
+        uint8_t dtr(void) { return (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
+        uint8_t rts(void) { return (usb_cdc2_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
+        operator bool() { return usb_configuration && (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) &&
+                ((uint32_t)(systick_millis_count - usb_cdc2_line_rtsdtr_millis) >= 15);
+        }
+        size_t readBytes(char *buffer, size_t length) {
+                size_t count=0;
+                unsigned long startMillis = millis();
+                do {
+                        count += usb_serial2_read(buffer + count, length - count);
+                        if (count >= length) return count;
+                } while(millis() - startMillis < _timeout);
+                setReadError();
+                return count;
+        }
+
+};
+extern usb_serial2_class SerialUSB1;
+extern void serialEventUSB1(void);
+#endif // __cplusplus
+
+#endif // CDC2_STATUS_INTERFACE && CDC2_DATA_INTERFACE
+
+
+
+#if defined(CDC3_STATUS_INTERFACE) && defined(CDC3_DATA_INTERFACE)
+
+// C language implementation
+#ifdef __cplusplus
+extern "C" {
+#endif
+void usb_serial3_configure(void);
+int usb_serial3_getchar(void);
+int usb_serial3_peekchar(void);
+int usb_serial3_available(void);
+int usb_serial3_read(void *buffer, uint32_t size);
+void usb_serial3_flush_input(void);
+int usb_serial3_putchar(uint8_t c);
+int usb_serial3_write(const void *buffer, uint32_t size);
+int usb_serial3_write_buffer_free(void);
+void usb_serial3_flush_output(void);
+extern uint32_t usb_cdc3_line_coding[2];
+extern volatile uint32_t usb_cdc3_line_rtsdtr_millis;
+extern volatile uint8_t usb_cdc3_line_rtsdtr;
+extern volatile uint8_t usb_cdc3_transmit_flush_timer;
+#ifdef __cplusplus
+}
+#endif
+
+// C++ interface
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial3_class : public Stream
+{
+public:
+        constexpr usb_serial3_class() {}
+        void begin(long) {
+                //uint32_t millis_begin = systick_millis_count;
+                //disabled for now - causes more trouble than it solves?
+                //while (!(*this)) {
+                        // wait up to 2.5 seconds for Arduino Serial Monitor
+                        // Yes, this is a long time, but some Windows systems open
+                        // the port very slowly.  This wait allows programs for
+                        // Arduino Uno to "just work" (without forcing a reboot when
+                        // the port is opened), and when no PC is connected the user's
+                        // sketch still gets to run normally after this wait time.
+                        //if ((uint32_t)(systick_millis_count - millis_begin) > 2500) break;
+                //}
+        }
+        void end() { /* TODO: flush output and shut down USB port */ };
+        virtual int available() { return usb_serial3_available(); }
+        virtual int read() { return usb_serial3_getchar(); }
+        virtual int peek() { return usb_serial3_peekchar(); }
+        virtual void flush() { usb_serial3_flush_output(); }  // TODO: actually wait for data to leave USB...
+        virtual void clear(void) { usb_serial3_flush_input(); }
+        virtual size_t write(uint8_t c) { return usb_serial3_putchar(c); }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return usb_serial3_write(buffer, size); }
+        size_t write(unsigned long n) { return write((uint8_t)n); }
+        size_t write(long n) { return write((uint8_t)n); }
+        size_t write(unsigned int n) { return write((uint8_t)n); }
+        size_t write(int n) { return write((uint8_t)n); }
+        virtual int availableForWrite() { return usb_serial3_write_buffer_free(); }
+        using Print::write;
+        void send_now(void) { usb_serial3_flush_output(); }
+        uint32_t baud(void) { return usb_cdc3_line_coding[0]; }
+        uint8_t stopbits(void) { uint8_t b = usb_cdc3_line_coding[1]; if (!b) b = 1; return b; }
+        uint8_t paritytype(void) { return usb_cdc3_line_coding[1] >> 8; } // 0=none, 1=odd, 2=even
+        uint8_t numbits(void) { return usb_cdc3_line_coding[1] >> 16; }
+        uint8_t dtr(void) { return (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
+        uint8_t rts(void) { return (usb_cdc3_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
+        operator bool() { return usb_configuration && (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) &&
+                ((uint32_t)(systick_millis_count - usb_cdc3_line_rtsdtr_millis) >= 15);
+        }
+        size_t readBytes(char *buffer, size_t length) {
+                size_t count=0;
+                unsigned long startMillis = millis();
+                do {
+                        count += usb_serial3_read(buffer + count, length - count);
+                        if (count >= length) return count;
+                } while(millis() - startMillis < _timeout);
+                setReadError();
+                return count;
+        }
+
+};
+extern usb_serial3_class SerialUSB2;
+extern void serialEventUSB2(void);
+#endif // __cplusplus
+
+#endif // CDC3_STATUS_INTERFACE && CDC3_DATA_INTERFACE
+
+
+
+
+

--- a/hardware/teensy/avr/cores/teensy4/usb_serial.h
+++ b/hardware/teensy/avr/cores/teensy4/usb_serial.h
@@ -33,9 +33,9 @@
 #include "usb_desc.h"
 #include <stdint.h>
 
-#if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
+#if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED) || defined(USB_NSGAMEPAD)
 
-#if !defined(USB_DISABLED)
+#if !(defined(USB_DISABLED) || defined(USB_NSGAMEPAD))
 
 // C language implementation
 #ifdef __cplusplus
@@ -126,7 +126,7 @@ extern usb_serial_class Serial;
 extern void serialEvent(void);
 #endif // __cplusplus
 
-#else  // !defined(USB_DISABLED)
+#else  // !(defined(USB_DISABLED) || defined(USB_NSGAMEPAD))
 
 // Allow Arduino programs using Serial to compile, but Serial will do nothing.
 #ifdef __cplusplus

--- a/hardware/teensy/avr/cores/teensy4/yield.cpp
+++ b/hardware/teensy/avr/cores/teensy4/yield.cpp
@@ -56,7 +56,7 @@ void yield(void)
 
 
 #if !defined(USB_JOYSTICK) && !defined(USB_NSGAMEPAD)
-	// USB Serail - Add hack to minimize impact...
+	// USB Serial - Add hack to minimize impact...
 	if (yield_active_check_flags & YIELD_CHECK_USB_SERIAL) {
 		if (Serial.available()) serialEvent();
 		if (_serialEvent_default) yield_active_check_flags &= ~YIELD_CHECK_USB_SERIAL;

--- a/hardware/teensy/avr/keywords.txt
+++ b/hardware/teensy/avr/keywords.txt
@@ -69,6 +69,9 @@ extmem_free	KEYWORD2
 extmem_calloc	KEYWORD2
 extmem_realloc	KEYWORD2
 strcasecmp	KEYWORD2
+DateTimeFields	LITERAL1
+breakTime	KEYWORD2
+makeTime	KEYWORD2
 
 # removed by Arduino 1.0, now also removed from Teensyduino
 #BYTE	LITERAL1

--- a/hardware/teensy/avr/keywords.txt
+++ b/hardware/teensy/avr/keywords.txt
@@ -8,6 +8,7 @@ nullptr	LITERAL1
 noexcept	LITERAL1
 static_assert	LITERAL1
 thread_local	LITERAL1
+size_t	LITERAL1
 
 # teensy specific functions
 elapsedMillis	LITERAL1
@@ -23,6 +24,7 @@ analogWriteFrequency	KEYWORD2
 touchRead	KEYWORD2
 Teensy3Clock	KEYWORD2
 IntervalTimer	KEYWORD2
+CrashReport	KEYWORD1
 printf	KEYWORD2
 digitalWriteFast	KEYWORD2
 digitalReadFast	KEYWORD2
@@ -62,6 +64,11 @@ waitForEvent	KEYWORD2
 MillisTimer	LITERAL1
 beginRepeating	KEYWORD2
 delayNanoseconds	KEYWORD2
+extmem_malloc	KEYWORD2
+extmem_free	KEYWORD2
+extmem_calloc	KEYWORD2
+extmem_realloc	KEYWORD2
+strcasecmp	KEYWORD2
 
 # removed by Arduino 1.0, now also removed from Teensyduino
 #BYTE	LITERAL1
@@ -106,6 +113,9 @@ analogInputToDigitalPin	KEYWORD2
 digitalPinHasPWM	KEYWORD2
 NOT_AN_INTERRUPT	LITERAL1
 digitalPinToInterrupt	KEYWORD2
+FILE_READ	LITERAL1
+FILE_WRITE	LITERAL1
+FILE_WRITE_BEGIN	LITERAL1
 
 # HardwareSerial modes
 SERIAL_7E1	LITERAL1


### PR DESCRIPTION
The project currently uses Teensyduino 1.53 and version 1.8.13 of the Arduino IDE (5ff5de72e4c2c5965a0f26fc5977cb6f057422ba). I've gone through and updated the Teensyduino versions for all project files to the last releases:

* Teensyduino 1.54 and Arduino 1.8.15 (347950a310189bb5201fbe9a63e1be2dd66795ff) ([CI](https://github.com/dmadison/NSGadget_Teensy/actions/runs/2364875799))
* Teensyduino 1.55 and Arduino 1.8.16 (9dbf83a5c0254ee0c097999146b958a1998469b1) ([CI](https://github.com/dmadison/NSGadget_Teensy/actions/runs/2364883627))
* Teensyduino 1.56 and Arduino 1.8.19 (a76ee36cb70c6dbd545d5217612a34310df338ba) ([CI](https://github.com/dmadison/NSGadget_Teensy/actions/runs/2364885069))

I've also added support for the Teensy 4 "MicroMod" board that was added with 1.54, and added some lines to the `.gitignore` to filter out core files which are unused by the project (to allow copy + pasting core folders).

This PR also includes a CI script to check for any compilation issues with all boards and examples. It's based off of the [ArduinoXInput_Teensy CI workflow](https://github.com/dmadison/ArduinoXInput_Teensy/blob/master/.github/workflows/ci.yml) and works great. The CI has found no compilation issues to date. For good measure I also added a CI badge to the README.

For compatibility with certain libraries that assume a `Serial` interface is always present (e.g. #2) I added a dummy Serial object for the `NS_Gamepad` mode. This isn't strictly necessary but it is quite convenient.

I've tested the latest version of the `NSGamepad` example on both a Teensy 3.2 and a Teensy 4.0 with my Nintendo Switch v2 and everything works as expected.

Please let me know if there's anything I can do on my end to get these updates merged. Thanks!